### PR TITLE
0.1.1 - support usage inside continuous build

### DIFF
--- a/Arduino.h
+++ b/Arduino.h
@@ -15,8 +15,8 @@
 // Macros defined when running under UnixHostDuino
 #define UNIX_HOST_DUINO 1
 // xx.yy.zz => xxyyzz (without leading 0)
-#define UNIX_HOST_DUINO_VERSION 100
-#define UNIX_HOST_DUINO_VERSION_STRING "0.1"
+#define UNIX_HOST_DUINO_VERSION 101
+#define UNIX_HOST_DUINO_VERSION_STRING "0.1.1"
 
 // Used by digitalRead() and digitalWrite()
 #define HIGH 0x1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 * Unreleased
-    * If the STDIN is not a real tty, don't bother putting it into raw mode,
-      to allow unit tests inside continuous build frameworks.
+* 0.1.1 (2019-08-14)
+    * If the STDIN is not a real tty, continue without putting it into raw mode
+      or exiting with an error. This allows unit tests inside continuous build
+      frameworks.
 * 0.1 (2019-07-31)
     * Split from `AUnit` and renamed from `unitduino` to `UnixHostDuino`.
     * Add `UNIT_HOST_DUINO` macro.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 * Unreleased
+    * If the STDIN is not a real tty, don't bother putting it into raw mode,
+      to allow unit tests inside continuous build frameworks.
 * 0.1 (2019-07-31)
     * Split from `AUnit` and renamed from `unitduino` to `UnixHostDuino`.
     * Add `UNIT_HOST_DUINO` macro.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The disadvantages are:
 * There may be compiler differences between the desktop and the embedded
   environments (e.g. 8-bit integers versus 64-bit integers).
 
-Version: 0.1 (2019-07-31)
+Version: 0.1.1 (2019-08-14)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,20 @@ See [CHANGELOG.md](CHANGELOG.md).
 
 [MIT License](https://opensource.org/licenses/MIT)
 
+## Bugs and Limitations
+
+If the executable (e.g. `SampleTest.out`) is piped to the `less(1)` or `more(1)`
+command, sometimes (not all the time) the executable hangs and displays nothing
+on the pager program. I don't know why, it probably has to do with the way that
+the `less` or `more` programs manipulate the `stdin`. The solution is to
+explicitly redirect the `stdin`:
+
+```
+$ ./SampleTest.out | less # hangs
+
+$ ./SampleTest.out < /dev/null | less # works
+```
+
 ## Feedback and Support
 
 If you have any questions, comments, bug reports, or feature requests, please

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Running an Arduino program natively on Linux or MacOS has some advantages:
 * The development cycle can be lot faster because the compilers on the the
   desktop machines are a lot faster, and we also avoid the upload and flash
   process to the microcontroller.
-* The desktop machine can run unit tests which are too much flash or too
+* The desktop machine can run unit tests which require too much flash or too
   much memory to fit inside an embedded microcontroller.
 
 The disadvantages are:


### PR DESCRIPTION
* 0.1.1 (2019-08-14)
    * If the STDIN is not a real tty, continue without putting it into raw mode
      or exiting with an error. This allows unit tests inside continuous build
      frameworks.
