### PR TITLE
0.1.2 - implement Serial.flush()

### DIFF
--- a/Arduino.h
+++ b/Arduino.h
@@ -15,8 +15,8 @@
 // Macros defined when running under UnixHostDuino
 #define UNIX_HOST_DUINO 1
 // xx.yy.zz => xxyyzz (without leading 0)
-#define UNIX_HOST_DUINO_VERSION 101
-#define UNIX_HOST_DUINO_VERSION_STRING "0.1.1"
+#define UNIX_HOST_DUINO_VERSION 102
+#define UNIX_HOST_DUINO_VERSION_STRING "0.1.2"
 
 // Used by digitalRead() and digitalWrite()
 #define HIGH 0x1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 * Unreleased
+* 0.1.2 (2019-09-04)
+    * Implement `StdioSerial::flush()` to enable `Serial.flush()`.
 * 0.1.1 (2019-08-14)
     * If the STDIN is not a real tty, continue without putting it into raw mode
       or exiting with an error. This allows unit tests inside continuous build

--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ the `less` or `more` programs manipulate the `stdin`. The solution is to
 explicitly redirect the `stdin`:
 
 ```
+$ ./SampleTest.out | grep failed # works
+
 $ ./SampleTest.out | less # hangs
 
 $ ./SampleTest.out < /dev/null | less # works

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The disadvantages are:
 * There may be compiler differences between the desktop and the embedded
   environments (e.g. 8-bit integers versus 64-bit integers).
 
-Version: 0.1.1 (2019-08-14)
+Version: 0.1.2 (2019-09-04)
 
 ## Usage
 
@@ -63,6 +63,17 @@ The output that would normally be printed on the `Serial` on an Arduino
 board will be sent to the `STDOUT` of the Linux or MacOS terminal. The output
 should be identical to what would be shown on the serial port of the Arduino
 controller.
+
+### Using an Alternate C++ Compiler
+
+Normally the C++ compiler on Linux is `g++`. If you have `clang++` installed
+you can use that instead by specifying the `CXX` environment variable:
+```
+$ CXX=clang++ make
+```
+(This sets the `CXX` shell environment variable temporarily, for the duration of
+the `make` command, which causes `make` to set its internal `CXX` variable,
+which causes `UnixHostDuino.mk` to use `clang++` over the default `g++`.)
 
 ### Difference from Arduino IDE
 

--- a/StdioSerial.cpp
+++ b/StdioSerial.cpp
@@ -11,4 +11,8 @@ size_t StdioSerial::write(uint8_t c) {
   return (result == EOF) ? 0 : 1;
 }
 
+void StdioSerial::flush() {
+  fflush(stdout);
+}
+
 StdioSerial Serial;

--- a/StdioSerial.h
+++ b/StdioSerial.h
@@ -19,6 +19,8 @@ class StdioSerial: public Stream {
 
     size_t write(uint8_t c) override;
 
+    void flush() override;
+
     operator bool() { return true; }
 
     int available() override { return mHead != mTail; }


### PR DESCRIPTION
* 0.1.2 (2019-09-04)
    * Implement `StdioSerial::flush()` to enable `Serial.flush()`.
