### PR TITLE
0.1.3 - Add installation instructions to README.md

### DIFF
--- a/Arduino.h
+++ b/Arduino.h
@@ -13,8 +13,8 @@
 #include "StdioSerial.h"
 
 // xx.yy.zz => xxyyzz (without leading 0)
-#define UNIX_HOST_DUINO_VERSION 102
-#define UNIX_HOST_DUINO_VERSION_STRING "0.1.2"
+#define UNIX_HOST_DUINO_VERSION 103
+#define UNIX_HOST_DUINO_VERSION_STRING "0.1.3"
 
 // Used by digitalRead() and digitalWrite()
 #define HIGH 0x1

--- a/Arduino.h
+++ b/Arduino.h
@@ -12,8 +12,6 @@
 #include "Print.h"
 #include "StdioSerial.h"
 
-// Macros defined when running under UnixHostDuino
-#define UNIX_HOST_DUINO 1
 // xx.yy.zz => xxyyzz (without leading 0)
 #define UNIX_HOST_DUINO_VERSION 102
 #define UNIX_HOST_DUINO_VERSION_STRING "0.1.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 * Unreleased
+    * Add 'Installation' section to the README.md.
+    * Add `UNIX_HOST_DUINO` macro symbol  to the CPPFLAGS to allow conditional
+      code that activates only when UnixHostDuino is used.
 * 0.1.2 (2019-09-04)
     * Implement `StdioSerial::flush()` to enable `Serial.flush()`.
 * 0.1.1 (2019-08-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* 0.1.3 (2019-11-21)
     * Add 'Installation' section to the README.md.
     * Add `UNIX_HOST_DUINO` macro symbol  to the CPPFLAGS to allow conditional
       code that activates only when UnixHostDuino is used.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UnixHostDuino
 
-This directory contains a small (but often effective) implementation of the
+This project contains a small (but often effective) implementation of the
 Arduino programming framework for Linux and MacOS. Originally, it was created to
 allow [AUnit](https://github.com/bxparks/AUnit) unit tests to be compiled and
 run on a Linux or MacOS machine, instead of running on the embedded
@@ -26,7 +26,7 @@ The disadvantages are:
 
 * Only a limited set of Arduino functions are supported (see below).
 * There may be compiler differences between the desktop and the embedded
-  environments (e.g. 8-bit integers versus 64-bit integers).
+  environments (e.g. 16-bit `int` versus 64-bit `int`).
 
 Version: 0.1.2 (2019-09-04)
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The disadvantages are:
 * There may be compiler differences between the desktop and the embedded
   environments (e.g. 16-bit `int` versus 64-bit `int`).
 
-Version: 0.1.2 (2019-09-04)
+Version: 0.1.3 (2019-11-21)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ The disadvantages are:
 
 Version: 0.1.2 (2019-09-04)
 
+## Installation
+
+You need to grab the sources directly from GitHub. This project is *not* an
+Arduino library so it is not available through the [Arduino Library
+Manager](https://www.arduino.cc/en/guide/libraries) in the Arduino IDE.
+
+The location of the UnixHostDuino directory can be arbitrary, but a convenient
+location might be the same `./libraries/` directory used by the Arduino IDE to
+store other Arduino libraries:
+
+```
+$ cd {sketchbook_directory}/libraries
+$ git clone https://github.com/bxparks/UnixHostDuino.git
+```
+
+This will create a directory called
+`{sketchbook_directory}/libraries/UnixHostDuino`.
+
 ## Usage
 
 The minimal `Makefile` has 3 lines:
@@ -124,8 +142,8 @@ and the following works for MacOS:
 
 If the Arduino program depends on additional Arduino libraries, they must be
 specified in the `Makefile` using the `ARDUINO_LIBS` parameter. For example,
-this includes the`[AUnit](https://github.com/bxparks/AUnit) library if it is at
-the same level as UnixHostDuino::
+this includes the [AUnit](https://github.com/bxparks/AUnit) library if it is at
+the same level as UnixHostDuino:
 
 ```
 APP_NAME := SampleTest

--- a/UnixHostDuino.mk
+++ b/UnixHostDuino.mk
@@ -62,6 +62,11 @@ CPPFLAGS_EXPANSION = -I$(module) -I$(module)/src
 CPPFLAGS ?=
 CPPFLAGS += $(foreach module,$(ALL_MODULES),$(CPPFLAGS_EXPANSION))
 
+# Define a macro to indicate that UnixHostDuino is being used. Defined here
+# instead of Arduino.h so that files like 'compat.h' can determine the
+# compile-time environment without having to include <Arduino.h>.
+CPPFLAGS += -DUNIX_HOST_DUINO
+
 # linker settings (e.g. -lm)
 LDFLAGS ?=
 


### PR DESCRIPTION
* 0.1.3 (2019-11-21)
    * Add 'Installation' section to the README.md.
    * Add `UNIX_HOST_DUINO` macro symbol  to the CPPFLAGS to allow conditional
      code that activates only when UnixHostDuino is used.
