### PR TITLE
Allow to use as a library

### DIFF
--- a/Arduino.cpp
+++ b/Arduino.cpp
@@ -123,7 +123,7 @@ static void handleControlC(int /*sig*/) {
 // Main loop. User code will provide setup() and loop().
 // -----------------------------------------------------------------------
 
-int main(int argc, char** argv) {
+extern "C" int __main(int argc, char** argv) {
   signal(SIGINT, handleControlC);
   atexit(disableRawMode);
 	enableRawMode();
@@ -137,3 +137,5 @@ int main(int argc, char** argv) {
     yield();
   }
 }
+
+extern "C" int main(int argc, char** argv) __attribute__((weak, alias("__main")));

--- a/Arduino.h
+++ b/Arduino.h
@@ -62,6 +62,11 @@ void setup();
 /** Provided in the client code's *.ino file. */
 void loop();
 
-}
+/** Default entrypoint, runs setup() and loop() */
+int unixhostduino_main(int argc, char** argv);
 
+/** Calls unixhostduino_main() unless overriden by user */
+int main(int argc, char** argv);
+
+}
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -91,10 +91,7 @@ static void handleControlC(int /*sig*/) {
 // Main loop. User code will provide setup() and loop().
 // -----------------------------------------------------------------------
 
-int main(int argc, char** argv)
-__attribute__((weak));
-
-int main(int argc, char** argv) {
+extern "C" int unixhostduino_main(int argc, char** argv) {
   signal(SIGINT, handleControlC);
   atexit(disableRawMode);
   enableRawMode();
@@ -107,4 +104,11 @@ int main(int argc, char** argv) {
     loop();
     yield();
   }
+}
+
+extern "C" int main(int argc, char** argv)
+__attribute__((weak));
+
+int main(int argc, char** argv) {
+  return unixhostduino_main(argc, argv);
 }


### PR DESCRIPTION
Hey,

About a month ago I was trying to unit testing support to an esp8266 project and it turned out to be quite easy to setup this repo as a base for Arduino emulation layer. But, because Arduino.cpp file defines `main()`, it is not possible to use it as a library (e.g., see this configuration file for PlatformIO - https://github.com/xoseperez/espurna/blob/dev/code/test/platformio.ini)

It is easily solved by adding `__attribute__((weak))` for `main()`
Also, in case someone would want to call this `main()` anyway, define the existing symbol by another name so it does not get stripped and user code can call  `__main()`

PS. I did see the README notice :)