### PR TITLE
merge v0.3 into master

### DIFF
--- a/Arduino.cpp
+++ b/Arduino.cpp
@@ -49,3 +49,4 @@ int digitalRead(uint8_t pin) { return 0; }
 
 void pinMode(uint8_t pin, uint8_t mode) {}
 
+int analogRead(uint8_t pin) { return 0; }

--- a/Arduino.h
+++ b/Arduino.h
@@ -46,6 +46,39 @@
 // Arbitrarily define the pin for the LED_BUILTIN
 #define LED_BUILTIN 1
 
+// Define a bunch of digital and analog pins
+#define D0 0
+#define D1 1
+#define D2 2
+#define D3 3
+#define D4 4
+#define D5 5
+#define D6 6
+#define D7 7
+#define D8 8
+#define D9 9
+#define D10 10
+#define D11 11
+#define D12 12
+#define D13 13
+#define D14 14
+#define D15 15
+#define D16 16
+#define D17 17
+#define D18 18
+#define D19 19
+
+#define A0 0
+#define A1 1
+#define A2 2
+#define A3 3
+#define A4 4
+#define A5 5
+#define A6 6
+#define A7 7
+#define A8 8
+#define A9 9
+
 extern "C" {
 
 void delay(unsigned long ms);
@@ -55,6 +88,7 @@ unsigned long micros();
 void digitalWrite(uint8_t pin, uint8_t val);
 int digitalRead(uint8_t pin);
 void pinMode(uint8_t pin, uint8_t mode);
+int analogRead(uint8_t pin);
 
 /** Provided in the client code's *.ino file. */
 void setup();

--- a/Arduino.h
+++ b/Arduino.h
@@ -13,8 +13,8 @@
 #include "StdioSerial.h"
 
 // xx.yy.zz => xxyyzz (without leading 0)
-#define UNIX_HOST_DUINO_VERSION 201
-#define UNIX_HOST_DUINO_VERSION_STRING "0.2.1"
+#define UNIX_HOST_DUINO_VERSION 300
+#define UNIX_HOST_DUINO_VERSION_STRING "0.3.0"
 
 // Used by digitalRead() and digitalWrite()
 #define HIGH 0x1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Unreleased
     * Add `#define` for various digital and analog pins: `D0`-`D19`, `A0`-`A9`.
     * Add stub for `analogRead()`.
+    * Add `Print.printf()` because a significant number of Arduino boards
+      (ESP8266, ESP32, Teensy, etc) support this extension.
 * 0.2.1 (2020-05-02)
     * Add `MORE_CLEAN`, an optional user-provided make-target to do additional
       cleaning, such as removing directories created by code-generators.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
 * Unreleased
+* 0.3 (2020-08-20)
     * Add `#define` for various digital and analog pins: `D0`-`D19`, `A0`-`A9`.
     * Add stub for `analogRead()`.
-    * Add `Print.printf()` because a significant number of Arduino boards
-      (ESP8266, ESP32, Teensy, etc) support this extension.
+    * Add `Print.printf()` provided by a significant number of Arduino boards
+      (ESP8266, ESP32, Teensy, etc).
 * 0.2.1 (2020-05-02)
     * Add `MORE_CLEAN`, an optional user-provided make-target to do additional
       cleaning, such as removing directories created by code-generators.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 * Unreleased
+    * Add `#define` for various digital and analog pins: `D0`-`D19`, `A0`-`A9`.
+    * Add stub for `analogRead()`.
 * 0.2.1 (2020-05-02)
     * Add `MORE_CLEAN`, an optional user-provided make-target to do additional
       cleaning, such as removing directories created by code-generators.

--- a/Print.cpp
+++ b/Print.cpp
@@ -2,21 +2,21 @@
  Print.cpp - Base class that provides print() and println()
  Copyright (c) 2008 David A. Mellis.  All right reserved.
  Modified by Brian T. Park 2019.
- 
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 2.1 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library; if not, write to the Free Software
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- 
+
  Modified 23 November 2006 by David A. Mellis
  Modified 03 August 2015 by Chuck Todd
  */
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdarg.h>
 #include <math.h>
 #include "pgmspace.h"
 #include "Print.h"
@@ -198,6 +199,21 @@ size_t Print::println(const Printable& x)
   return n;
 }
 
+size_t Print::printf(const char* fmt, ...) {
+  char buf[200];
+  va_list args;
+  va_start(args, fmt);
+  int status = vsnprintf(buf, 200, fmt, args);
+  va_end(args);
+  if (status >= 0) {
+    buf[199] = '\0';
+    size_t n = print(buf);
+    return n;
+  } else {
+    return 0;
+  }
+}
+
 // Private Methods /////////////////////////////////////////////////////////////
 
 size_t Print::printNumber(unsigned long n, uint8_t base)
@@ -220,15 +236,15 @@ size_t Print::printNumber(unsigned long n, uint8_t base)
   return write(str);
 }
 
-size_t Print::printFloat(double number, uint8_t digits) 
-{ 
+size_t Print::printFloat(double number, uint8_t digits)
+{
   size_t n = 0;
-  
+
   if (isnan(number)) return print("nan");
   if (isinf(number)) return print("inf");
   if (number > 4294967040.0) return print ("ovf");  // constant determined empirically
   if (number <-4294967040.0) return print ("ovf");  // constant determined empirically
-  
+
   // Handle negative numbers
   if (number < 0.0)
   {
@@ -240,7 +256,7 @@ size_t Print::printFloat(double number, uint8_t digits)
   double rounding = 0.5;
   for (uint8_t i=0; i<digits; ++i)
     rounding /= 10.0;
-  
+
   number += rounding;
 
   // Extract the integer part of the number and print it
@@ -250,7 +266,7 @@ size_t Print::printFloat(double number, uint8_t digits)
 
   // Print the decimal point, but only if there are digits beyond
   if (digits > 0) {
-    n += print('.'); 
+    n += print('.');
   }
 
   // Extract digits from the remainder one at a time
@@ -259,8 +275,8 @@ size_t Print::printFloat(double number, uint8_t digits)
     remainder *= 10.0;
     unsigned int toPrint = (unsigned int)(remainder);
     n += print(toPrint);
-    remainder -= toPrint; 
-  } 
-  
+    remainder -= toPrint;
+  }
+
   return n;
 }

--- a/Print.cpp
+++ b/Print.cpp
@@ -19,7 +19,8 @@
 
  Modified 23 November 2006 by David A. Mellis
  Modified 03 August 2015 by Chuck Todd
- */
+ Modified 2018 by Brian T. Park
+*/
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -28,6 +29,9 @@
 #include <math.h>
 #include "pgmspace.h"
 #include "Print.h"
+
+// Size of the internal printf() buffer
+#define PRINTF_BUFFER_SIZE 250
 
 // Public Methods //////////////////////////////////////////////////////////////
 
@@ -200,13 +204,13 @@ size_t Print::println(const Printable& x)
 }
 
 size_t Print::printf(const char* fmt, ...) {
-  char buf[200];
+  char buf[PRINTF_BUFFER_SIZE];
   va_list args;
   va_start(args, fmt);
-  int status = vsnprintf(buf, 200, fmt, args);
+  int status = vsnprintf(buf, PRINTF_BUFFER_SIZE, fmt, args);
   va_end(args);
   if (status >= 0) {
-    buf[199] = '\0';
+    buf[PRINTF_BUFFER_SIZE - 1] = '\0';
     size_t n = print(buf);
     return n;
   } else {

--- a/Print.h
+++ b/Print.h
@@ -46,10 +46,10 @@ class Print
     void setWriteError(int err = 1) { write_error = err; }
   public:
     Print() : write_error(0) {}
-  
+
     int getWriteError() { return write_error; }
     void clearWriteError() { setWriteError(0); }
-  
+
     virtual size_t write(uint8_t) = 0;
     size_t write(const char *str) {
       if (str == NULL) return 0;
@@ -88,6 +88,10 @@ class Print
     size_t println(double, int = 2);
     size_t println(const Printable&);
     size_t println(void);
+
+    // printf() extension supported by many microcontrollers including
+    // Teensy, ESP8266 and ESP32 (but not AVR).
+    size_t printf(const char* format, ...);
 
     virtual void flush() { /* Empty implementation for backward compatibility */ }
 };

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The disadvantages are:
 * There may be compiler differences between the desktop and the embedded
   environments (e.g. 16-bit `int` versus 64-bit `int`).
 
-Version: 0.2.1 (2020-05-02)
+Version: 0.3 (2020-08-20)
 
 ## Installation
 
@@ -200,6 +200,7 @@ The following functions and features of the Arduino framework are implemented:
     * `delay()`, `yield()`
     * `millis()`, `micros()`
     * `digitalWrite()`, `digitalRead()`, `pinMode()` (empty stubs)
+    * `analogRead()` (empty stub)
     * `HIGH`, `LOW`, `INPUT`, `OUTPUT`, `INPUT_PULLUP`
 * `StdioSerial.h`
     * `Serial.print()`, `Serial.println()`, `Serial.write()`
@@ -207,9 +208,11 @@ The following functions and features of the Arduino framework are implemented:
     * `SERIAL_PORT_MONITOR`
 * `WString.h`
     * `class String`
-    * `class __FlashStringHelper`, `F()`
+    * `class __FlashStringHelper`, `F()`, `FPSTR()`
 * `Print.h`
     * `class Print`, `class Printable`
+    * `Print.printf()` - extended function supported by some Arduino compatible
+      microcontrollers
 * `pgmspace.h`
     * `pgm_read_byte()`, `pgm_read_word()`, `pgm_read_dword()`,
       `pgm_read_float()`, `pgm_read_ptr()`
@@ -223,6 +226,12 @@ The following functions and features of the Arduino framework are implemented:
 
 See [Arduino.h](https://github.com/bxparks/UnixHostDuino/blob/develop/Arduino.h)
 for the latest list.
+
+The `Print.printf()` function is an extension to the `Print` class that is
+provided by many Arduino-compatible microcontrollers (but not the AVR
+controllers). It is implemented here for convenience. The size of the internal
+buffer is `250` characters, which can be changed by changing the
+`PRINTF_BUFFER_SIZE` parameter if needed.
 
 ### Serial Port Emulation
 
@@ -270,6 +279,9 @@ This library has been tested on:
     * clang++ 8.0.0-3~ubuntu18.04.2
     * clang++ 6.0.0-1ubuntu2
     * GNU Make 4.1
+* Ubuntu 20.04
+    * g++ (Ubuntu 9.3.0-10ubuntu2) 9.3.0
+    * GNU Make 4.2.1
 * MacOS 10.14.5
     * clang++ Apple LLVM version 10.0.1
     * GNU Make 3.81

--- a/UnixHostDuino.mk
+++ b/UnixHostDuino.mk
@@ -38,9 +38,9 @@
 UNAME := $(shell uname)
 
 # UnixHostDuino module directory.
-UNIX_HOST_DUINO_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
+UNIX_HOST_DUINO_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 # Assume that there are other libs are siblings to UnixHostDuino
-UNIX_HOST_DUINO_LIB_DIR := $(realpath $(UNIX_HOST_DUINO_DIR)/..)
+UNIX_HOST_DUINO_LIB_DIR := $(abspath $(UNIX_HOST_DUINO_DIR)/..)
 
 # List of Arduino IDE library folders, both built-in to the Arduino IDE
 # and those downloaded later, e.g. in the portable/ directory or .arduino15/

--- a/WString.h
+++ b/WString.h
@@ -3,7 +3,7 @@
   ...mostly rewritten by Paul Stoffregen...
   Copyright (c) 2009-10 Hernando Barragan.  All right reserved.
   Copyright 2011, Paul Stoffregen, paul@pjrc.com
-  Modified by Brian T. Park 2019.
+  Modified 2019, Brian T. Park
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
* 0.3 (2020-08-20)
    * Add `#define` for various digital and analog pins: `D0`-`D19`, `A0`-`A9`.
    * Add stub for `analogRead()`.
    * Add `Print.printf()` provided by a significant number of Arduino boards
      (ESP8266, ESP32, Teensy, etc).
