### PR TITLE
Add PlatformIO library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,25 @@
+{
+    "name": "EpoxyDuino",
+    "version": "0.7.0",
+    "description": "Compile and run Arduino programs natively on Linux, MacOS and FreeBSD.",
+    "keywords": [
+        "unit-test",
+        "mock",
+        "arduino",
+        "native"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/bxparks/EpoxyDuino.git"
+    },
+    "authors": {
+        "name": "Brian Park"
+    },
+    "license": "MIT",
+    "platforms": [
+        "native"
+    ],
+    "build": {
+        "includeDir": "cores/epoxy"
+    }
+}


### PR DESCRIPTION
This PR allows this library to be included as a PlatformIO dependency. Only the basic library is supported, not any of the extras in the `libraries` directory. PlatformIO doesn't support multiple libraries in a single repo (https://community.platformio.org/t/how-to-install-libraries-from-a-github-repos-subfolders/13458), but I think basic support is better than none.

In the past (version <=0.5), the files were all in the base directory, so PlatformIO could figure out how to build it without any help. Since the headers are now in a subdirectory, a `library.json` file is necessary to allow PlatformIO to find them.