### PR TITLE
Add better Mocking for SPI

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,0 @@
-{
-	// Use IntelliSense to learn about possible attributes.
-	// Hover to view descriptions of existing attributes.
-	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-	"version": "0.2.0",
-	"configurations": []
-}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,7 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": []
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 * Unreleased
+    * Add better SPI Mocking
+      * `transferWriteValue()` To see previous values written via SPI
+         * configurable by changing BUFFERSIZE in SPI.h
+      * `transferReturnValue()` Set return value for a SPI transfer
+      * `getCallCount()` To get number of times `transfer()` or `transfer16()` have been called
     * Add `strncat_P()` to `pgmspace.h`.
 * 1.5.0 (2022-12-08)
     * Support compiling plain `*.c` files in libraries and in the application.

--- a/cores/epoxy/SPI.cpp
+++ b/cores/epoxy/SPI.cpp
@@ -39,9 +39,7 @@ uint8_t SPIClass::transfer(uint8_t data)
 {
 
 	addToBuffer(data);
-	/*return what was in readbuffer
-	  cast to uint8_t is safe as truncation will happen*/
-	  callCount++;
+	callCount++;
 	return (uint8_t)readBuffer;
 }
 

--- a/cores/epoxy/SPI.cpp
+++ b/cores/epoxy/SPI.cpp
@@ -51,7 +51,7 @@ void SPIClass::transferReturnValue(uint16_t data)
 /*Number of calls previous written value*/
 uint16_t SPIClass::transferWriteValue(uint8_t n)
 {
-	return writeBuffer[((n-1)%4)];
+	return writeBuffer[((n-1)%BUFFERSIZE)];
 }
 
 void SPIClass::resetWriteBuffer()
@@ -63,9 +63,9 @@ void SPIClass::resetWriteBuffer()
 void SPIClass::addToBuffer(uint16_t data)
 {
 	/*clear write buffer*/
-	writeBuffer[callCount%4] = 0x0000;
+	writeBuffer[callCount%BUFFERSIZE] = 0x0000;
 	/*set lower byte to transferred value*/
-	writeBuffer[callCount%4] |= data;
+	writeBuffer[callCount%BUFFERSIZE] |= data;
 }
 
 uint8_t SPIClass::getCallCount(){

--- a/cores/epoxy/SPI.cpp
+++ b/cores/epoxy/SPI.cpp
@@ -14,10 +14,62 @@
 
 #include "SPI.h"
 
+/*Read and write buffers for mocking. 16 bits to support transfer16*/
+#define BUFFERSIZE 4
+uint16_t readBuffer = 0x0000;
+uint16_t writeBuffer[BUFFERSIZE];
+uint8_t callCount = 0;
+
 SPIClass SPI;
 
-void SPIClass::end() { }
+void SPIClass::end() {}
 
-void SPIClass::usingInterrupt(uint8_t /*interruptNumber*/) { }
+void SPIClass::usingInterrupt(uint8_t /*interruptNumber*/) {}
 
-void SPIClass::notUsingInterrupt(uint8_t /*interruptNumber*/) { }
+void SPIClass::notUsingInterrupt(uint8_t /*interruptNumber*/) {}
+
+uint16_t SPIClass::transfer16(uint16_t data)
+{
+	addToBuffer(data);
+	callCount++;
+	return readBuffer;
+}
+
+uint8_t SPIClass::transfer(uint8_t data)
+{
+
+	addToBuffer(data);
+	/*return what was in readbuffer
+	  cast to uint8_t is safe as truncation will happen*/
+	  callCount++;
+	return (uint8_t)readBuffer;
+}
+
+void SPIClass::transferReturnValue(uint16_t data)
+{
+	readBuffer = data;
+}
+
+/*Number of calls previous written value*/
+uint16_t SPIClass::transferWriteValue(uint8_t n)
+{
+	return writeBuffer[((n-1)%4)];
+}
+
+void SPIClass::resetWriteBuffer()
+{
+	memset(writeBuffer, 0, sizeof(uint16_t)*BUFFERSIZE);
+	callCount = 0;
+}
+
+void SPIClass::addToBuffer(uint16_t data)
+{
+	/*clear write buffer*/
+	writeBuffer[callCount%4] = 0x0000;
+	/*set lower byte to transferred value*/
+	writeBuffer[callCount%4] |= data;
+}
+
+uint8_t SPIClass::getCallCount(){
+	return callCount;
+}

--- a/cores/epoxy/SPI.h
+++ b/cores/epoxy/SPI.h
@@ -111,8 +111,7 @@ public:
   */
   void transferReturnValue(uint16_t data);
 
-  /*Returns what was written n calls ago by either transfer() or transfer16()
-    MAX = 4*/
+  /*Returns what was written at call n since the last time resetWriteBuffer was called*/
   uint16_t transferWriteValue(uint8_t n);
 
   uint16_t transfer16(uint16_t data);

--- a/cores/epoxy/SPI.h
+++ b/cores/epoxy/SPI.h
@@ -35,7 +35,7 @@
 // A mismatch occurs if other libraries fail to use SPI.endTransaction() for
 // each SPI.beginTransaction().  Connect an LED to this pin.  The LED will turn
 // on if any mismatch is ever detected.
-//#define SPI_TRANSACTION_MISMATCH_LED 5
+// #define SPI_TRANSACTION_MISMATCH_LED 5
 
 #define SPI_CLOCK_DIV4 0x00
 #define SPI_CLOCK_DIV16 0x01
@@ -50,38 +50,37 @@
 #define SPI_MODE2 0x08
 #define SPI_MODE3 0x0C
 
-#define SPI_MODE_MASK 0x0C  // CPOL = bit 3, CPHA = bit 2 on SPCR
-#define SPI_CLOCK_MASK 0x03  // SPR1 = bit 1, SPR0 = bit 0 on SPCR
-#define SPI_2XCLOCK_MASK 0x01  // SPI2X = bit 0 on SPSR
+#define SPI_MODE_MASK 0x0C    // CPOL = bit 3, CPHA = bit 2 on SPCR
+#define SPI_CLOCK_MASK 0x03   // SPR1 = bit 1, SPR0 = bit 0 on SPCR
+#define SPI_2XCLOCK_MASK 0x01 // SPI2X = bit 0 on SPSR
 
 // define SPI_AVR_EIMSK for AVR boards with external interrupt pins
 #if defined(EIMSK)
-  #define SPI_AVR_EIMSK  EIMSK
+#define SPI_AVR_EIMSK EIMSK
 #elif defined(GICR)
-  #define SPI_AVR_EIMSK  GICR
+#define SPI_AVR_EIMSK GICR
 #elif defined(GIMSK)
-  #define SPI_AVR_EIMSK  GIMSK
+#define SPI_AVR_EIMSK GIMSK
 #endif
 
-/*Read and write buffers for mocking. 16 bits to support transfer16*/
-static uint16_t readBuffer = 0x0000;
-static uint16_t writeBuffer = 0x0000;
 
-class SPISettings {
+class SPISettings
+{
 public:
   SPISettings(uint32_t /*clock*/, uint8_t /*bitOrder*/, uint8_t /*dataMode*/)
-    { }
-  SPISettings() { }
+  {
+  }
+  SPISettings() {}
 
 private:
   friend class SPIClass;
 };
 
-
-class SPIClass {
+class SPIClass
+{
 public:
   // Initialize the SPI library
-  static void begin() { }
+  static void begin() {}
 
   // If SPI is used from within an interrupt, this function registers
   // that interrupt with the SPI library, so beginTransaction() can
@@ -100,63 +99,51 @@ public:
   // Before using SPI.transfer() or asserting chip select pins,
   // this function is used to gain exclusive access to the SPI bus
   // and configure the correct settings.
-  inline static void beginTransaction(SPISettings /*settings*/) { }
+  inline static void beginTransaction(SPISettings /*settings*/) {}
 
- // Write to the SPI bus (MOSI pin) and also receive (MISO pin)
-  inline static uint8_t transfer(uint8_t data)
-  {
-    /*clear write buffer*/
-    writeBuffer = 0x0000;
-    /*set lower byte to transferred value*/
-    writeBuffer |= data;
-    /*return what was in readbuffer
-      cast to uint8_t is safe as truncation will happen*/
-    return (uint8_t)readBuffer;
-  }
+  // Write to the SPI bus (MOSI pin) and also receive (MISO pin)
+  uint8_t transfer(uint8_t data);
 
   /*Used to set return value of subsequent transfer/transfer16 function calls
 
     transfer() and transfer16() will return either the lower byte or both bytes of this
     set value depending on which transfer() was called
   */
-  inline static void transferReturnValue(uint16_t data) { readBuffer = data; }
+  void transferReturnValue(uint16_t data);
 
-  /*Returns what was last written by either transfer() or transfer16()*/
-  inline static uint16_t transferWriteValue(void) { return writeBuffer; }
+  /*Returns what was written n calls ago by either transfer() or transfer16()
+    MAX = 4*/
+  uint16_t transferWriteValue(uint8_t n);
 
-  inline static uint16_t transfer16(uint16_t data)
-  {
-    /*clear write buffer*/
-    writeBuffer = 0x0000;
-    /*set to transferred value*/
-    writeBuffer |= data;
-    /*return what was in readbuffer
-      cast to uint8_t is safe as truncation will happen*/
-    return readBuffer;
-  }
-  inline static void transfer(void * /*buf*/, size_t /*count*/) { }
+  uint16_t transfer16(uint16_t data);
+
+  inline static void transfer(void * /*buf*/, size_t /*count*/) {}
   // After performing a group of transfers and releasing the chip select
   // signal, this function allows others to access the SPI bus
-  inline static void endTransaction(void) { }
+  inline static void endTransaction(void) {}
 
   // Disable the SPI bus
   static void end();
 
   // This function is deprecated.  New applications should use
   // beginTransaction() to configure SPI settings.
-  inline static void setBitOrder(uint8_t /*bitOrder*/) { }
+  inline static void setBitOrder(uint8_t /*bitOrder*/) {}
   // This function is deprecated.  New applications should use
   // beginTransaction() to configure SPI settings.
-  inline static void setDataMode(uint8_t /*dataMode*/) { }
+  inline static void setDataMode(uint8_t /*dataMode*/) {}
   // This function is deprecated.  New applications should use
   // beginTransaction() to configure SPI settings.
-  inline static void setClockDivider(uint8_t /*clockDiv*/) { }
+  inline static void setClockDivider(uint8_t /*clockDiv*/) {}
 
   // These undocumented functions should not be used.  SPI.transfer()
   // polls the hardware flag which is automatically cleared as the
   // AVR responds to SPI's interrupt
-  inline static void attachInterrupt() { }
-  inline static void detachInterrupt() { }
+  inline static void attachInterrupt() {}
+  inline static void detachInterrupt() {}
+
+  void resetWriteBuffer();
+  void addToBuffer(uint16_t data);
+  uint8_t getCallCount();
 };
 
 extern SPIClass SPI;

--- a/tests/SPIMockTest/Makefile
+++ b/tests/SPIMockTest/Makefile
@@ -1,0 +1,3 @@
+APP_NAME := SPIMockTest
+ARDUINO_LIBS := AUnit
+include ../../EpoxyDuino.mk

--- a/tests/SPIMockTest/SPIMockTest.ino
+++ b/tests/SPIMockTest/SPIMockTest.ino
@@ -146,7 +146,7 @@ test(SPIMockTestBase, readWrite16)
 }
 
 /*Test that we are able to see the return value of the last two SPI Writes*/
-test(SPIMockTestMultiple, dualWrite){
+test(SPIMockTestMultiple, dualWrite8){
 
 	SPI_START;
 
@@ -170,7 +170,7 @@ test(SPIMockTestMultiple, dualWrite){
 }
 /*Test that we are able to see the return value of the last three SPI Writes*/
 
-test(SPIMockTestMultiple, tripleWrite){
+test(SPIMockTestMultiple, tripleWrite8){
 	
 	SPI_START;
 
@@ -197,7 +197,7 @@ test(SPIMockTestMultiple, tripleWrite){
 }
 /*Test that we are able to see the return value of the last four SPI Writes*/
 
-test(SPIMockTestMultiple, quadWrite){
+test(SPIMockTestMultiple, quadWrite8){
 	
 	SPI_START;
 
@@ -228,21 +228,21 @@ test(SPIMockTestMultiple, quadWrite){
 /*Test that we are able to see the return value of the last 4 SPI Writes
   where we have written five times so we should have a rollover*/
 
-test(SPIMockTestMultiple, pentaWrite){
+test(SPIMockTestMultiple, pentaWrite8){
 		
 	SPI_START;
 
 	/*three SPI transfers*/
-	SPI.transfer(0x11); //buffer[0]
-	SPI.transfer(0x22); //buffer[1]
-	SPI.transfer(0x33); //buffer[2]
-	SPI.transfer(0x44); //buffer[3]
-	SPI.transfer(0x55); //buffer[0]
+	SPI.transfer(0x11); 
+	SPI.transfer(0x22); 
+	SPI.transfer(0x33); 
+	SPI.transfer(0x44); 
+	SPI.transfer(0x55); 
 
 	SPI_END;
 
 	/* get the four previous writes*/
-	uint16_t secondCall = SPI.transferWriteValue(2); //buffer[(1-1)%4] = buffer[0]
+	uint16_t secondCall = SPI.transferWriteValue(2); 
 	uint16_t thirdCall = SPI.transferWriteValue(3);
 	uint16_t fourthCall = SPI.transferWriteValue(4);
 	uint16_t fifthCall = SPI.transferWriteValue(5);
@@ -260,6 +260,123 @@ test(SPIMockTestMultiple, pentaWrite){
 	assertEqual(0x5, callCount);
 
 }
+
+/*Test that we are able to see the return value of the last two SPI Writes*/
+test(SPIMockTestMultiple, dualWrite16){
+
+	SPI_START;
+
+	/*two SPI transfers*/
+	SPI.transfer16(0x1122);
+	SPI.transfer16(0x2233);
+
+	SPI_END;
+
+	/* get the two previous writes*/
+	uint16_t firstCall = SPI.transferWriteValue(1);
+	uint16_t secondCall = SPI.transferWriteValue(2);
+
+	SPI.resetWriteBuffer();
+
+	/* Make sure they are equal*/
+	assertEqual(0x1122, firstCall);
+	assertEqual(0x2233, secondCall);
+
+
+}
+/*Test that we are able to see the return value of the last three SPI Writes*/
+
+test(SPIMockTestMultiple, tripleWrite16){
+	
+	SPI_START;
+
+	/*three SPI transfers*/
+	SPI.transfer16(0x1122);
+	SPI.transfer16(0x2233);
+	SPI.transfer16(0x3344);
+
+	SPI_END;
+
+	/* get the three previous writes*/
+	uint16_t firstCall = SPI.transferWriteValue(1);
+	uint16_t secondCall = SPI.transferWriteValue(2);
+	uint16_t thirdCall = SPI.transferWriteValue(3);
+
+	SPI.resetWriteBuffer();
+
+	/* Make sure they are equal*/
+	assertEqual(0x1122, firstCall);
+	assertEqual(0x2233, secondCall);
+	assertEqual(0x3344, thirdCall);
+
+
+}
+/*Test that we are able to see the return value of the last four SPI Writes*/
+
+test(SPIMockTestMultiple, quadWrite16){
+	
+	SPI_START;
+
+	/*three SPI transfers*/
+	SPI.transfer16(0x1122);
+	SPI.transfer16(0x2233); 
+	SPI.transfer16(0x3344); 
+	SPI.transfer16(0x4455); 
+
+	SPI_END;
+
+	/* get the four previous writes*/
+	uint16_t firstCall = SPI.transferWriteValue(1); 
+	uint16_t secondCall = SPI.transferWriteValue(2); 
+	uint16_t thirdCall = SPI.transferWriteValue(3); 
+	uint16_t fourthCall = SPI.transferWriteValue(4); 
+
+	SPI.resetWriteBuffer();
+
+	/* Make sure they are equal*/
+	assertEqual(0x1122, firstCall);
+	assertEqual(0x2233, secondCall);
+	assertEqual(0x3344, thirdCall);
+	assertEqual(0x4455, fourthCall);
+
+
+}
+/*Test that we are able to see the return value of the last 4 SPI Writes
+  where we have written five times so we should have a rollover*/
+
+test(SPIMockTestMultiple, pentaWrite16){
+		
+	SPI_START;
+
+	/*three SPI transfers*/
+	SPI.transfer16(0x1122); 
+	SPI.transfer16(0x2233); 
+	SPI.transfer16(0x3344); 
+	SPI.transfer16(0x4455); 
+	SPI.transfer16(0x5566); 
+
+	SPI_END;
+
+	/* get the four previous writes*/
+	uint16_t secondCall = SPI.transferWriteValue(2); 
+	uint16_t thirdCall = SPI.transferWriteValue(3);
+	uint16_t fourthCall = SPI.transferWriteValue(4);
+	uint16_t fifthCall = SPI.transferWriteValue(5);
+
+	uint8_t callCount = SPI.getCallCount();
+
+	SPI.resetWriteBuffer();
+
+	/* Make sure they are equal*/
+	assertEqual(0x2233, secondCall);
+	assertEqual(0x3344, thirdCall);
+	assertEqual(0x4455, fourthCall);
+	assertEqual(0x5566, fifthCall);
+	//Make sure call count is as expected
+	assertEqual(0x5, callCount);
+
+}
+
 
 void setup()
 {

--- a/tests/SPIMockTest/SPIMockTest.ino
+++ b/tests/SPIMockTest/SPIMockTest.ino
@@ -1,0 +1,146 @@
+#line 2 "SPIMockTest"
+
+#include <Arduino.h>
+#include <AUnit.h>
+#include <SPI.h>
+
+using aunit::TestRunner;
+
+#define csPin 10
+
+/* Macros to make starting and ending easier*/
+#define SPI_START digitalWrite(csPin, LOW)
+#define SPI_END digitalWrite(csPin, HIGH)
+
+/*Test writing 8 bits with SPI*/
+test(SPIMockTest, write8)
+{
+
+	SPI_START;
+
+	/*Write 8 bits*/
+	SPI.transfer(0x8F);
+
+	SPI_END;
+
+	/*Get value that we wrote*/
+	uint16_t writtenValue = SPI.transferWriteValue();
+
+	/*Make sure we actually wrote 0x8F*/
+	assertEqual(0x8F, writtenValue);
+}
+
+/*Test writing 16 bits with SPI*/
+test(SPIMockTest, write16)
+{
+
+	SPI_START;
+
+	/*Write 16 bits*/
+	SPI.transfer16(0x8F8F);
+
+	SPI_END;
+
+	/*Get value that we wrote*/
+	uint16_t writtenValue = SPI.transferWriteValue();
+
+	/*Make sure we actually wrote 0x8F*/
+	assertEqual(0x8F8F, writtenValue);
+}
+
+/*Test reading a given 8 bits with SPI*/
+test(SPIMockTest, read8)
+{
+
+	/*Setting expected read value*/
+	SPI.transferReturnValue(0x5F);
+
+	SPI_START;
+
+	/*Write 8 bits so we can get a read 8 bits*/
+	uint16_t readValue = SPI.transfer(0x8F);
+
+	SPI_END;
+
+	/*Make sure we actually read 0x8F*/
+	assertEqual(0x5F, readValue);
+}
+
+/*Test reading a given 16 bits with SPI*/
+test(SPIMockTest, read16)
+{
+
+	/*Setting expected read value*/
+	SPI.transferReturnValue(0x5F5F);
+
+	SPI_START;
+
+	/*Write 8 bits so we can get a read 8 bits*/
+	uint16_t readValue = SPI.transfer16(0x8F8F);
+
+	SPI_END;
+
+	/*Make sure we actually read 0x8F*/
+	assertEqual(0x5F5F, readValue);
+}
+
+/*Test that we can both read and write values at the same time
+  8 bits at a time*/
+test(SPIMockTest, readWrite8)
+{
+
+	/*Setting expected read value*/
+	SPI.transferReturnValue(0xFF);
+
+	SPI_START;
+
+	/*Write 8 bits*/
+	uint16_t readValue = SPI.transfer(0x88);
+
+	SPI_END;
+
+	/*get value we wrote*/
+	uint16_t writtenValue = SPI.transferWriteValue();
+	/*Ensure we wrote read and wrote correct 8 bits*/
+	assertEqual(0xFF, readValue);
+	assertEqual(0x88, writtenValue);
+}
+
+test(SPIMockTest, readWrite16)
+{
+
+	/*Setting expected read value*/
+	SPI.transferReturnValue(0xFF88);
+
+	SPI_START;
+
+	/*Write 8 bits*/
+	uint16_t readValue = SPI.transfer16(0x88FF);
+
+	SPI_END;
+
+	/*get value we wrote*/
+	uint16_t writtenValue = SPI.transferWriteValue();
+	/*Ensure we wrote read and wrote correct 8 bits*/
+	assertEqual(0xFF88, readValue);
+	assertEqual(0x88FF, writtenValue);
+}
+
+void setup()
+{
+
+#if !defined(EPOXY_DUINO)
+	delay(1000); // wait to prevent garbage on SERIAL_PORT_MONITOR
+#endif
+
+	SERIAL_PORT_MONITOR.begin(115200);
+	while (!SERIAL_PORT_MONITOR)
+		; // needed for Leonardo/Micro
+
+	SPI.begin();
+}
+
+void loop()
+{
+	TestRunner::run();
+}

--- a/tests/SPIMockTest/SPIMockTest.ino
+++ b/tests/SPIMockTest/SPIMockTest.ino
@@ -317,7 +317,7 @@ test(SPIMockTestMultiple, quadWrite16){
 	
 	SPI_START;
 
-	/*three SPI transfers*/
+	/*four SPI transfers*/
 	SPI.transfer16(0x1122);
 	SPI.transfer16(0x2233); 
 	SPI.transfer16(0x3344); 
@@ -348,7 +348,7 @@ test(SPIMockTestMultiple, pentaWrite16){
 		
 	SPI_START;
 
-	/*three SPI transfers*/
+	/*five SPI transfers*/
 	SPI.transfer16(0x1122); 
 	SPI.transfer16(0x2233); 
 	SPI.transfer16(0x3344); 

--- a/tests/SPIMockTest/SPIMockTest.ino
+++ b/tests/SPIMockTest/SPIMockTest.ino
@@ -13,7 +13,7 @@ using aunit::TestRunner;
 #define SPI_END digitalWrite(csPin, HIGH)
 
 /*Test writing 8 bits with SPI*/
-test(SPIMockTest, write8)
+test(SPIMockTestBase, write8)
 {
 
 	SPI_START;
@@ -24,32 +24,37 @@ test(SPIMockTest, write8)
 	SPI_END;
 
 	/*Get value that we wrote*/
-	uint16_t writtenValue = SPI.transferWriteValue();
+	uint16_t writtenValue = SPI.transferWriteValue(1);
+	SPI.resetWriteBuffer();
 
 	/*Make sure we actually wrote 0x8F*/
 	assertEqual(0x8F, writtenValue);
+
 }
 
 /*Test writing 16 bits with SPI*/
-test(SPIMockTest, write16)
+test(SPIMockTestBase, write16)
 {
 
 	SPI_START;
 
 	/*Write 16 bits*/
-	SPI.transfer16(0x8F8F);
+	SPI.transfer16(0x5F5F);
 
 	SPI_END;
 
 	/*Get value that we wrote*/
-	uint16_t writtenValue = SPI.transferWriteValue();
+	uint16_t writtenValue = SPI.transferWriteValue(1);
+	SPI.resetWriteBuffer();
 
 	/*Make sure we actually wrote 0x8F*/
-	assertEqual(0x8F8F, writtenValue);
+	assertEqual(0x5F5F, writtenValue);
+
+
 }
 
 /*Test reading a given 8 bits with SPI*/
-test(SPIMockTest, read8)
+test(SPIMockTestBase, read8)
 {
 
 	/*Setting expected read value*/
@@ -61,13 +66,15 @@ test(SPIMockTest, read8)
 	uint16_t readValue = SPI.transfer(0x8F);
 
 	SPI_END;
+	SPI.resetWriteBuffer();
 
 	/*Make sure we actually read 0x8F*/
 	assertEqual(0x5F, readValue);
+
 }
 
 /*Test reading a given 16 bits with SPI*/
-test(SPIMockTest, read16)
+test(SPIMockTestBase, read16)
 {
 
 	/*Setting expected read value*/
@@ -80,13 +87,16 @@ test(SPIMockTest, read16)
 
 	SPI_END;
 
+	SPI.resetWriteBuffer();
+
 	/*Make sure we actually read 0x8F*/
 	assertEqual(0x5F5F, readValue);
+
 }
 
 /*Test that we can both read and write values at the same time
   8 bits at a time*/
-test(SPIMockTest, readWrite8)
+test(SPIMockTestBase, readWrite8)
 {
 
 	/*Setting expected read value*/
@@ -100,13 +110,18 @@ test(SPIMockTest, readWrite8)
 	SPI_END;
 
 	/*get value we wrote*/
-	uint16_t writtenValue = SPI.transferWriteValue();
+	uint16_t writtenValue = SPI.transferWriteValue(1);
+
+	SPI.resetWriteBuffer();
+
 	/*Ensure we wrote read and wrote correct 8 bits*/
 	assertEqual(0xFF, readValue);
 	assertEqual(0x88, writtenValue);
-}
 
-test(SPIMockTest, readWrite16)
+}
+/*Test that we can both read and write values at the same time
+  16 bits at a time*/
+test(SPIMockTestBase, readWrite16)
 {
 
 	/*Setting expected read value*/
@@ -120,10 +135,130 @@ test(SPIMockTest, readWrite16)
 	SPI_END;
 
 	/*get value we wrote*/
-	uint16_t writtenValue = SPI.transferWriteValue();
+	uint16_t writtenValue = SPI.transferWriteValue(1);
+
+	SPI.resetWriteBuffer();
+
 	/*Ensure we wrote read and wrote correct 8 bits*/
 	assertEqual(0xFF88, readValue);
 	assertEqual(0x88FF, writtenValue);
+
+}
+
+/*Test that we are able to see the return value of the last two SPI Writes*/
+test(SPIMockTestMultiple, dualWrite){
+
+	SPI_START;
+
+	/*two SPI transfers*/
+	SPI.transfer(0x11);
+	SPI.transfer(0x22);
+
+	SPI_END;
+
+	/* get the two previous writes*/
+	uint16_t firstCall = SPI.transferWriteValue(1);
+	uint16_t secondCall = SPI.transferWriteValue(2);
+
+	SPI.resetWriteBuffer();
+
+	/* Make sure they are equal*/
+	assertEqual(0x11, firstCall);
+	assertEqual(0x22, secondCall);
+
+
+}
+/*Test that we are able to see the return value of the last three SPI Writes*/
+
+test(SPIMockTestMultiple, tripleWrite){
+	
+	SPI_START;
+
+	/*three SPI transfers*/
+	SPI.transfer(0x11);
+	SPI.transfer(0x22);
+	SPI.transfer(0x33);
+
+	SPI_END;
+
+	/* get the three previous writes*/
+	uint16_t firstCall = SPI.transferWriteValue(1);
+	uint16_t secondCall = SPI.transferWriteValue(2);
+	uint16_t thirdCall = SPI.transferWriteValue(3);
+
+	SPI.resetWriteBuffer();
+
+	/* Make sure they are equal*/
+	assertEqual(0x11, firstCall);
+	assertEqual(0x22, secondCall);
+	assertEqual(0x33, thirdCall);
+
+
+}
+/*Test that we are able to see the return value of the last four SPI Writes*/
+
+test(SPIMockTestMultiple, quadWrite){
+	
+	SPI_START;
+
+	/*three SPI transfers*/
+	SPI.transfer(0x11); //buffer[0]
+	SPI.transfer(0x22); //buffer[1]
+	SPI.transfer(0x33); //buffer[2]
+	SPI.transfer(0x44); //buffer[3]
+
+	SPI_END;
+
+	/* get the four previous writes*/
+	uint16_t firstCall = SPI.transferWriteValue(1); //buffer[(4-1)%4] = buffer[3]
+	uint16_t secondCall = SPI.transferWriteValue(2); //buffer[(3-1)%4] = buffer[2]
+	uint16_t thirdCall = SPI.transferWriteValue(3); //buffer[(2-1)%4] = buffer[1]
+	uint16_t fourthCall = SPI.transferWriteValue(4); //buffer[(1-1)%4] = buffer[0]
+
+	SPI.resetWriteBuffer();
+
+	/* Make sure they are equal*/
+	assertEqual(0x11, firstCall);
+	assertEqual(0x22, secondCall);
+	assertEqual(0x33, thirdCall);
+	assertEqual(0x44, fourthCall);
+
+
+}
+/*Test that we are able to see the return value of the last 4 SPI Writes
+  where we have written five times so we should have a rollover*/
+
+test(SPIMockTestMultiple, pentaWrite){
+		
+	SPI_START;
+
+	/*three SPI transfers*/
+	SPI.transfer(0x11); //buffer[0]
+	SPI.transfer(0x22); //buffer[1]
+	SPI.transfer(0x33); //buffer[2]
+	SPI.transfer(0x44); //buffer[3]
+	SPI.transfer(0x55); //buffer[0]
+
+	SPI_END;
+
+	/* get the four previous writes*/
+	uint16_t secondCall = SPI.transferWriteValue(2); //buffer[(1-1)%4] = buffer[0]
+	uint16_t thirdCall = SPI.transferWriteValue(3);
+	uint16_t fourthCall = SPI.transferWriteValue(4);
+	uint16_t fifthCall = SPI.transferWriteValue(5);
+
+	uint8_t callCount = SPI.getCallCount();
+
+	SPI.resetWriteBuffer();
+
+	/* Make sure they are equal*/
+	assertEqual(0x22, secondCall);
+	assertEqual(0x33, thirdCall);
+	assertEqual(0x44, fourthCall);
+	assertEqual(0x55, fifthCall);
+	//Make sure call count is as expected
+	assertEqual(0x5, callCount);
+
 }
 
 void setup()
@@ -137,7 +272,10 @@ void setup()
 	while (!SERIAL_PORT_MONITOR)
 		; // needed for Leonardo/Micro
 
+	TestRunner::setTimeout(0);
+
 	SPI.begin();
+
 }
 
 void loop()


### PR DESCRIPTION
Removed Stubs for `SPI.transfer()` and `SPI.transfer16()` and replaced with logic to mock.

Added:

`uint16_t transferWriteValue(void)`
-- Allows user to see what was last written in a `transfer()` or `trasnfer16()` call.  It takes a 16 bit value but when working with
    `transfer()` it truncates the given value.

`void transferReturnValue(uint16_t data)`
-- Allows user to set expected return value from a `transfer()` or `transfer16()` call.  Expects 16 bit value.

Included 6 test cases to verify logic.