### PR TITLE
Add constructors to line-up with SoftwareSerial.

### DIFF
--- a/cores/epoxy/StdioSerial.cpp
+++ b/cores/epoxy/StdioSerial.cpp
@@ -7,6 +7,11 @@
 #include <unistd.h>
 #include "StdioSerial.h"
 
+StdioSerial::StdioSerial() {
+}
+
+StdioSerial::StdioSerial(int8_t rxPin, int8_t txPin, bool invert) {}
+
 size_t StdioSerial::write(uint8_t c) {
   ssize_t status = ::write(STDOUT_FILENO, &c, 1);
   return (status <= 0) ? 0 : 1;

--- a/cores/epoxy/StdioSerial.h
+++ b/cores/epoxy/StdioSerial.h
@@ -15,6 +15,9 @@
  */
 class StdioSerial: public Stream {
   public:
+    StdioSerial();
+    StdioSerial(int8_t rxPin, int8_t txPin = -1, bool invert = false);
+    
     void begin(unsigned long /*baud*/) { bufch = -1; }
 
     size_t write(uint8_t c) override;


### PR DESCRIPTION
`SoftwareSerial` for Arduino by default has at least two constructors - one that takes no parameters, and one that takes three parameters with some specifying optional values.

In my Windows Arduino installation, the header and cpp for `SoftwareSerial` are found here: `C:\Users\username\AppData\Local\Arduino15\packages\esp8266\hardware\esp8266\3.1.2\libraries\SoftwareSerial\src`. The header has:

``` 
UARTBase();
UARTBase(int8_t rxPin, int8_t txPin = -1, bool invert = false);
```

Similar implementations are found here, in this `espsoftwareserial` repo's [SoftwareSerial.h](https://github.com/plerup/espsoftwareserial/blob/4034c7a789b5beabbce69b48eb60c8a7124ce48d/src/SoftwareSerial.h#L175).

Adding these two constructors enables building and running code that would normally target `SoftwareSerial` and point it to `StdioSerial` instead, such as [AirGradient's air quality sensor implementation](https://github.com/airgradienthq/arduino/blob/33520c18fece15a80e8bc2406892ae112c68cc73/AirGradient.cpp#L66). Keeping the constructor with no parameters should prevent any issues with current uses of `StdioSerial`.

Theoretically this could go a few steps further to specify pins and maybe manipulate how EpoxyDuino responds, but at this point I feel just building the code is a step forward.