### PR TITLE
Fix Client class definition

### DIFF
--- a/cores/epoxy/Client.h
+++ b/cores/epoxy/Client.h
@@ -37,7 +37,7 @@ class Client: public Stream {
         virtual size_t write(const uint8_t *buf, size_t size) override = 0;
         virtual int available() override = 0;
         virtual int read() override = 0;
-        /* virtual int read(uint8_t *buf, size_t size) override = 0; */
+        virtual int read(uint8_t *buf, size_t size) = 0;
         virtual int peek() override = 0;
         virtual void flush() override = 0;
         virtual void stop() = 0;

--- a/cores/epoxy/Client.h
+++ b/cores/epoxy/Client.h
@@ -48,7 +48,7 @@ class Client: public Stream {
         }
 
         #if defined(EPOXY_CORE_ESP8266)
-        const uint8_t* rawIPAddress(IPAddress& addr) const {
+        const uint8_t* rawIPAddress(IPAddress& addr) {
             return addr.raw_address();
         }
         #endif

--- a/cores/epoxy/Client.h
+++ b/cores/epoxy/Client.h
@@ -48,7 +48,7 @@ class Client: public Stream {
         }
 
         #if defined(EPOXY_CORE_ESP8266)
-        const uint8_t* rawIPAddress(IPAddress& addr) {
+        const uint8_t* rawIPAddress(const IPAddress& addr) {
             return addr.raw_address();
         }
         #endif

--- a/cores/epoxy/Client.h
+++ b/cores/epoxy/Client.h
@@ -22,8 +22,6 @@
 #ifndef EPOXY_DUINO_CLIENT_H
 #define EPOXY_DUINO_CLIENT_H
 
-#if defined(EPOXY_CORE_ESP8266)
-
 #include "Print.h"
 #include "Stream.h"
 #include "IPAddress.h"
@@ -44,15 +42,16 @@ class Client: public Stream {
         virtual uint8_t connected() = 0;
         virtual operator bool() = 0;
     protected:
-		/* does not compile
+
         uint8_t* rawIPAddress(IPAddress& addr) {
             return addr.raw_address();
         }
-        const uint8_t* rawIPAddress(const IPAddress& addr) {
+
+        #if defined(EPOXY_CORE_ESP8266)
+        const uint8_t* rawIPAddress(IPAddress& addr) const {
             return addr.raw_address();
         }
-				*/
+        #endif
 };
 
-#endif
 #endif


### PR DESCRIPTION
Hi.

I have made some minor corrections to the definition of the Client class.

The `virtual int read(uint8_t *buf, size_t size)` method cannot be **overridden** because it does not exist in the Stream class.

The **Client class** does not require an ESP core, as it is an abstract class that is part of the Arduino API. For example, it is possible to [use it on AVR](https://github.com/arduino/ArduinoCore-avr/blob/master/cores/arduino/Client.h) with the Ethernet library.

I have left the dependency on EPOXY_CORE_ESP8266 because in the **IPAddress class** it is indicated that way for the `rawIPAddress(IPAddress& addr)` constant method, but I have corrected the syntax error that prevented compilation.

I hope this helps.
Regards.
