### PR TITLE
Add support for sending serial output to STDERR

### DIFF
--- a/cores/epoxy/StdioSerial.cpp
+++ b/cores/epoxy/StdioSerial.cpp
@@ -7,8 +7,28 @@
 #include <unistd.h>
 #include "StdioSerial.h"
 
+// Set default output when compiling
+#ifndef STDERR_OUTPUT
+#define SERIAL_OUTPUT StdioOutput::STDOUT
+#else 
+#define SERIAL_OUTPUT StdioOutput::STDERR
+#endif
+
+ // Constructor to set the output when an object is instantiated
+StdioSerial::StdioSerial() { setOutput(SERIAL_OUTPUT); }
+
+// Select the output at runtime
+void StdioSerial::setOutput(StdioOutput output) {
+  if (output == StdioOutput::STDOUT) {
+    outputFd = STDOUT_FILENO;
+  } else if (output == StdioOutput::STDERR) {
+    outputFd = STDERR_FILENO;
+  }
+}
+
+// Write to selected output
 size_t StdioSerial::write(uint8_t c) {
-  ssize_t status = ::write(STDOUT_FILENO, &c, 1);
+  ssize_t status = ::write(outputFd, &c, 1);
   return (status <= 0) ? 0 : 1;
 }
 

--- a/cores/epoxy/StdioSerial.h
+++ b/cores/epoxy/StdioSerial.h
@@ -10,11 +10,22 @@
 #include "Stream.h"
 
 /**
- * A version of Serial that reads from STDIN and sends output to STDOUT on
- * Linux or MacOS.
+ * A version of Serial that reads from STDIN and sends output to STDOUT or
+ * STDERR on Linux or MacOS.
  */
+
+// Class to enumerate the two output options: STDOUT or STDERR
+enum class StdioOutput { 
+  STDOUT, 
+  STDERR 
+};
+
 class StdioSerial: public Stream {
   public:
+    StdioSerial(); // Constructor to set the output when an object is instantiated
+
+    void setOutput(StdioOutput output); // Set the output for write/print methods
+
     void begin(unsigned long /*baud*/) { bufch = -1; }
 
     size_t write(uint8_t c) override;
@@ -38,6 +49,7 @@ class StdioSerial: public Stream {
 
   private:
     int bufch;
+    int outputFd; // Store the selected output 
 };
 
 extern StdioSerial Serial;


### PR DESCRIPTION
Hi.

I am a grateful user of this software, but I needed to be able to send serial output to **STDERR** instead of **STDOUT**.

I have added support to be able to select the output both at compile time and at runtime. And by the way, I have implemented the `flush()` method which was not there.

I hope it helps you.
Regards.

