### PR TITLE
support app source files up to any depth

### DIFF
--- a/EpoxyDuino.mk
+++ b/EpoxyDuino.mk
@@ -191,15 +191,14 @@ MODULE_EXPANSION_C = $(wildcard $(module)/*.c) \
 	$(wildcard $(module)/src/*/*/*/*.c)
 MODULE_SRCS_CPP += $(foreach module,$(EPOXY_MODULES),$(MODULE_EXPANSION_CPP))
 MODULE_SRCS_C += $(foreach module,$(EPOXY_MODULES),$(MODULE_EXPANSION_C))
-# 3) Collect the source files in the application directory, also 3 levels down.
-APP_SRCS_CPP += $(wildcard *.cpp) \
-	$(wildcard */*.cpp) \
-	$(wildcard */*/*.cpp) \
-	$(wildcard */*/*/*.cpp)
-APP_SRCS_C += $(wildcard *.c) \
-	$(wildcard */*.c) \
-	$(wildcard */*/*.c) \
-	$(wildcard */*/*/*.c)
+# 3) Collect the source files in the application directory. Also follows symlinks.
+ifeq ($(OS),Windows_NT)
+	APP_SRCS_CPP += $(shell dir /S /B src/*.cpp)
+	APP_SRCS_C += $(shell dir /S /B src/*.c)
+else
+	APP_SRCS_CPP += $(shell find -L src -name '*.cpp')
+	APP_SRCS_C += $(shell find -L src -name '*.c')
+endif
 
 # Generate the list of object files from the *.cpp, *.c, and *.ino files.
 OBJS += $(EPOXY_SRCS:%.cpp=%.o)


### PR DESCRIPTION
Replaces the wildcards for APP_SRCS_{C,CPP} with shell commands to find c/cpp files in any subdirectories of src.

Because this relies on shell commands, it needs to check for the OS. This could be replaced by a recursive function(?) entirely in Make, but that seems more complex and less readable:
```Makefile
# (from Google Gemini, not tested:)
rwildcard = $(foreach d,$(wildcard $(1)*),$(call rwildcard,$(d)/,$(2)) $(filter $(subst *,%,$(2)),$(d)))

SRCS_CPP := $(call rwildcard, src/, *.cpp)
SRCS_C   := $(call rwildcard, src/, *.c)
```

I have tested the solution on Linux in a project of mine, however, for Windows I only tested the shell commands manually through wine, so if anyone wants to do a proper test, I would appreciate it.